### PR TITLE
add missing cstring header

### DIFF
--- a/SBC/rpi-4/SoapyRadioberrySDR/SoapyRadioberry.hpp
+++ b/SBC/rpi-4/SoapyRadioberrySDR/SoapyRadioberry.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string.h>
 #include <mutex>
+#include <cstring>
 #include "radioberry_ioctl.h"
 #include "i2c.h"
 


### PR DESCRIPTION
`std::memset` is defined in `<cstring>`. Depending on the files present on the compiling system, this may or may not be covered by the SoapySDR headers, but I think it's better to `#include` the stuff that's used locally instead of relying on third-party headers.