### PR TITLE
Non `pi` user installation

### DIFF
--- a/SBC/rpi-4/releases/dev/pihpsdr_install.sh
+++ b/SBC/rpi-4/releases/dev/pihpsdr_install.sh
@@ -79,21 +79,21 @@ elif [[ $input == "pihpsdr" ]]; then
 
 	make -j 4
 	sudo make install
-	if [ ! -d "/home/pi/.pihpsdr" ]; then
-		mkdir /home/pi/.pihpsdr
+	if [ ! -d "${HOME}/.pihpsdr" ]; then
+		mkdir ${HOME}/.pihpsdr
 	fi
-	cp release/pihpsdr/hpsdr.png /home/pi/.pihpsdr
+	cp release/pihpsdr/hpsdr.png ${HOME}/.pihpsdr
 	cd ..
 	rm -rf pihpsdr
 	
-	rm /home/pi/Desktop/pihpsdr.desktop
-	file="/home/pi/Desktop/pihpsdr.desktop"
+	rm ${HOME}/Desktop/pihpsdr.desktop || true
+	file="${HOME}/Desktop/pihpsdr.desktop"
 	echo "[Desktop Entry]" >> $file
-	echo "Icon=/home/pi/.pihpsdr/hpsdr.png" >> $file
+	echo "Icon=${HOME}/.pihpsdr/hpsdr.png" >> $file
 	echo "Exec=/usr/local/bin/pihpsdr" >> $file
 	echo "Type=Application" >> $file
 	echo "Terminal=false" >> $file
-	echo "Path=/home/pi/.pihpsdr" >> $file
+	echo "Path=${HOME}/.pihpsdr" >> $file
 	cat $file
 	
 	echo ""

--- a/SBC/rpi-4/releases/dev/pihpsdr_install.sh
+++ b/SBC/rpi-4/releases/dev/pihpsdr_install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 echo "Installation wdsp or pihpsdr"
+echo "----------------------------"
+echo "NOTE. Before building and installing pihpsdr you should to install wdsp."
 echo ""
 
 echo "What do you like to install [wdsp/pihpsdr/reboot] ?"


### PR DESCRIPTION
Update installation script for installing for non `pi` users on raspberry.
Also added installation note about `wdsp` is required for `pihpsdr`.

R9FEU 73.