### PR TITLE
Fix compilation warnings

### DIFF
--- a/SBC/rpi-4/device_driver/firmware/bias.c
+++ b/SBC/rpi-4/device_driver/firmware/bias.c
@@ -1,18 +1,19 @@
 
 #include "bias.h"
+#include <sys/ioctl.h>
 
-int fd_i2c_bias;
-int i2c_bias_handler;
+static int fd_i2c_bias;
+static int i2c_bias_handler;
 
 
-void init_I2C_bias() {
+void init_I2C_bias(void) {
 	
 	fd_i2c_bias = open("/dev/i2c-1", O_RDWR);
 
 	if (fd_i2c_bias < 0 ) {
 		fprintf(stderr, "Your SBC device is missing the following driver: '/dev/i2c-1' \n");
 		fprintf(stderr, "Change of Bias Setting is not possible\n");
-		return fd_i2c_bias;
+		return ;// fd_i2c_bias;
 	}
 	i2c_bias_handler = ioctl(fd_i2c_bias, I2C_SLAVE, ADDR_BIAS);
 
@@ -31,7 +32,7 @@ void write_I2C_bias(uint8_t control, uint8_t data) {
 	else fprintf(stderr, "Write I2C Bias command failed \n"); 
 }
 
-void close_I2C_bias() {
-	if (fd_i2c_bias != NULL) close(fd_i2c_bias);
+void close_I2C_bias(void) {
+	if (fd_i2c_bias >= 0) close(fd_i2c_bias);
 }
 //end of source

--- a/SBC/rpi-4/device_driver/firmware/bias.h
+++ b/SBC/rpi-4/device_driver/firmware/bias.h
@@ -29,11 +29,9 @@
 
 #define ADDR_BIAS 0x2C
 
-extern int fd_i2c_bias;
-extern int i2c_bias_handler;
-
 void openI2C_bias(void);
 void write_I2C_bias(uint8_t control, uint8_t data);
 void close_I2C_bias(void);
+void init_I2C_bias(void);
 
 #endif

--- a/SBC/rpi-4/device_driver/firmware/measure.c
+++ b/SBC/rpi-4/device_driver/firmware/measure.c
@@ -1,11 +1,12 @@
 
 #include "measure.h"
+#include <sys/ioctl.h>
 
 int i2c_measure_module_active;
-int fd_i2c_measure;
-int i2c_measure_handler;
+static int fd_i2c_measure;
+static int i2c_measure_handler;
 
-int config_I2C_measure(){
+int config_I2C_measure(void){
 	
 	uint8_t measure_config[1];
 	measure_config[0] = 0x07;
@@ -18,7 +19,7 @@ int config_I2C_measure(){
 	return result;
 }; 
 
-void openI2C_measure() {
+void openI2C_measure(void) {
 	
 	i2c_measure_module_active = 0;
 	
@@ -27,7 +28,7 @@ void openI2C_measure() {
 	if (fd_i2c_measure < 0 ) {
 		fprintf(stderr, "Your SBC device is missing the following driver: '/dev/i2c-1' \n");
 		fprintf(stderr, "Measurement is not possible\n");
-		return fd_i2c_measure;
+		return;
 	}
 	i2c_measure_handler = ioctl(fd_i2c_measure, I2C_SLAVE, ADDR_MEAS);
 
@@ -44,7 +45,7 @@ void read_I2C_measure(int *current, int *temperature){
 	*current = (int)(((measure_data[4] & 0x0F) <<8) | measure_data[5]);
 };
 
-void close_I2C_measure() {
-	if (fd_i2c_measure != NULL) close(fd_i2c_measure);
+void close_I2C_measure(void) {
+	if (fd_i2c_measure >= 0) close(fd_i2c_measure);
 };
 //end of source

--- a/SBC/rpi-4/device_driver/firmware/measure.h
+++ b/SBC/rpi-4/device_driver/firmware/measure.h
@@ -29,9 +29,6 @@
 
 extern int i2c_measure_module_active;
 
-extern int fd_i2c_measure;
-extern int i2c_measure_handler;
-
 void openI2C_measure(void);
 void read_I2C_measure(int *current, int *temperature);
 void close_I2C_measure(void);

--- a/SBC/rpi-4/device_driver/firmware/radioberry.h
+++ b/SBC/rpi-4/device_driver/firmware/radioberry.h
@@ -54,12 +54,12 @@ int pa_temp_ok = 1;
 uint32_t spi_commands[CAPACITY] = {0};
 uint32_t p_read = 0;
 uint32_t p_write = 0;
-mask(val)  { return val & (CAPACITY - 1); }
-push(val)  { assert(!full()); spi_commands[mask(p_write++)] = val; }
-pop()      { assert(!empty()); return spi_commands[mask(p_read++)]; }
-empty()    { return p_read == p_write; }
-full()     { return size() == CAPACITY; }
-size()     { return p_write - p_read; }
+static inline int size(void)     { return p_write - p_read; }
+static inline int empty(void)    { return p_read == p_write; }
+static inline int full(void)     { return size() == CAPACITY; }
+static inline int mask(int val)  { return val & (CAPACITY - 1); }
+static inline int push(int val)  { assert(!full()); spi_commands[mask(p_write++)] = val; }
+static inline int pop(void)      { assert(!empty()); return spi_commands[mask(p_read++)]; }
 
 char rb_control = 0x00;
 
@@ -75,23 +75,23 @@ int closerb = 0;
 
 int rb_sleep = 100;
 
-int initRadioberry();
-void runRadioberry(void);
-int closeRadioberry();
+static int initRadioberry(void);
+static void runRadioberry(void);
+static void closeRadioberry(void);
 
-void sendPacket(void);
-void handlePacket(char* buffer);
-void processPacket(char* buffer);
-void fillPacketToSend(void);
+static void sendPacket(void);
+static void handlePacket(char* buffer);
+static void processPacket(char* buffer);
+static void fillPacketToSend(void);
 
-void *packetreader(void *arg);
-void *txWriter(void *arg);
+static void *packetreader(void *arg);
+static void *txWriter(void *arg);
 
-void send_control(unsigned char command);
-float timedifference_msec(struct timeval t0, struct timeval t1);
+static void send_control(unsigned char command);
+static float timedifference_msec(struct timeval t0, struct timeval t1);
 
-void put_tx_buffer(unsigned char  value);
-unsigned char get_tx_buffer(void);
+static void put_tx_buffer(unsigned char  value);
+static unsigned char get_tx_buffer(void);
 
 int sock_TCP_Server = -1;
 int sock_TCP_Client = -1;

--- a/SBC/rpi-4/device_driver/firmware/register.c
+++ b/SBC/rpi-4/device_driver/firmware/register.c
@@ -1,8 +1,12 @@
 #include "register.h"
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
 
-char macaddress[24];
-char* radiocall; 
-char* radiolocator;
+static char macaddress[24];
+static char* radiocall;
+static char* radiolocator;
 char gatewareversion[16];
 char driverversion[16];
 char firmwareversion[16]; 
@@ -95,14 +99,15 @@ ssize_t process_http(int sockfd, char *host, char *page, char *poststr)
 {
 	char sendline[MAXLINE + 1], recvline[MAXLINE + 1];
 	ssize_t n;
-	snprintf(sendline, MAXSUB,
+	n = snprintf(sendline, MAXSUB,
 		 "POST %s HTTP/1.0\r\n"
 		 "Host: %s\r\n"
 		 "Content-type: application/x-www-form-urlencoded\r\n"
-		 "Content-length: %d\r\n\r\n"
+		 "Content-length: %zu\r\n\r\n"
 		 "%s", page, host, strlen(poststr), poststr);
 
-	write(sockfd, sendline, strlen(sendline));
+	if(write(sockfd, sendline, n) < 0)
+	    return -errno;
 	//get response
 	while ((n = read(sockfd, recvline, MAXLINE)) > 0) {
 		recvline[n] = '\0';

--- a/SBC/rpi-4/device_driver/firmware/register.h
+++ b/SBC/rpi-4/device_driver/firmware/register.h
@@ -21,9 +21,6 @@ struct _PROPERTY {
 	PROPERTY* next_property;
 };
 
-extern char macaddress[24];
-extern char* radiocall; 
-extern char* radiolocator;
 extern char gatewareversion[16];
 extern char driverversion[16];
 extern char firmwareversion[16]; 


### PR DESCRIPTION
This PR suggests 
1. fixes for the compilation warnings issued by gcc-10 and gcc-11.
2. declaring local things `static`
3. declaring parameterless C functions as `func(void)`
