### PR TITLE
kernel rpi6.6.y fix

### DIFF
--- a/SBC/rpi-4/SoapyRadioberrySDR/CMakeLists.txt
+++ b/SBC/rpi-4/SoapyRadioberrySDR/CMakeLists.txt
@@ -29,7 +29,7 @@ if (NOT SoapySDR_FOUND)
     message(WARNING "SoapySDR development files not found - skipping support")
     return()
 endif ()
-set(CMAKE_CXX_STANDARD 14)
+
 #include_directories(${MY_DEVICE_INCLUDE_DIRS})
 SOAPY_SDR_MODULE_UTIL(
     TARGET SoapyRadioberrySDR

--- a/SBC/rpi-4/SoapyRadioberrySDR/SoapyRadioberry.hpp
+++ b/SBC/rpi-4/SoapyRadioberrySDR/SoapyRadioberry.hpp
@@ -16,7 +16,6 @@
 
 #define TX_MAX 4800
 #define TX_MAX_BUFFER (TX_MAX * 8)
-const int npackages = 4;
 
 typedef enum radioberrysdrStreamFormat {
 	RADIOBERRY_SDR_CF32,

--- a/SBC/rpi-4/device_driver/driver/Makefile
+++ b/SBC/rpi-4/device_driver/driver/Makefile
@@ -1,3 +1,5 @@
+CCFLAGS += -Wcast-function-type
+
 KERNEL_HEADERS=/lib/modules/$(shell uname -r)/build
 
 obj-m := radioberry.o

--- a/SBC/rpi-4/device_driver/driver/radioberry.c
+++ b/SBC/rpi-4/device_driver/driver/radioberry.c
@@ -79,14 +79,14 @@ static struct device* radioberryCharDevice = NULL;
 static int _nrx = 1;
 
 static unsigned int irqNumber; 
-static unsigned int gpioRxSamplesiPin = 25; 
+static struct gpio_desc *gpio_desc = NULL;
 
 static irq_handler_t radioberry_irq_handler(unsigned int irq, void *dev_id, struct pt_regs *regs){
 	wake_up_interruptible(&rx_sample_queue);
     return (irq_handler_t) IRQ_HANDLED;      
 }
 
-static void firmware_load(char *firmware, int size) {
+static void firmware_load(const char *firmware, int size) {
 	printk(KERN_INFO "inside %s function \n", __FUNCTION__);
 	
 	u8 *buf = kmalloc(size + 1, GFP_KERNEL);
@@ -150,7 +150,7 @@ static int radioberry_open(struct inode *inode, struct file *filep) {
 		  return -EBUSY;
 	}	
 	int *minor = (int *)kmalloc(sizeof(int), GFP_KERNEL);
-	int major = MAJOR(inode->i_rdev);
+	// not used int major = MAJOR(inode->i_rdev);
 	*minor = MINOR(inode->i_rdev);
 	filep->private_data = (void *)minor;
 	
@@ -230,8 +230,30 @@ static struct file_operations radioberry_fops = {
 
 static int radioberry_probe(struct platform_device *pdev)
 {
-	printk(KERN_INFO "inside %s function \n", __FUNCTION__);
-	struct device *dev = &pdev->dev;	
+	printk(KERN_INFO "inside %s function \n", __FUNCTION__);	
+	if(!device_property_present(&pdev->dev, "rx-sample-gpio")) 
+		printk("radioberry - Error! Device property 'rx-sample-gpio' not found!\n");
+	else
+		printk("radioberry - Device property 'rx-sample-gpio' found!\n");
+			
+	gpio_desc = gpiod_get(&pdev->dev, "rx-sample", GPIOD_ASIS);
+	if(IS_ERR(gpio_desc)) {
+		printk("Failed to get GPIO rx-sample-gpio\n");
+		return -1 * IS_ERR(gpio_desc);
+	}
+    printk("Got GPIO rx-sample-gpio\n");
+	
+	int retval = gpiod_direction_input(gpio_desc);
+	if (retval) {
+        printk("Failed to set GPIO pin direction\n");
+        return retval;
+    }
+	irqNumber = gpiod_to_irq(gpio_desc);
+    if (irqNumber < 0) {
+        printk("Failed to get IRQ number for GPIO pin\n");
+        return irqNumber;
+    }
+	printk(KERN_INFO "Radioberry: The rx samples pin is mapped to IRQ: %d\n", irqNumber);
 	return 0;
 }
 
@@ -259,9 +281,6 @@ static struct platform_driver radioberry_driver = {
 };
 
 static int __init radioberry_init(void) {
-	int retval;
-	size_t size;
-
 	printk(KERN_INFO "inside %s function \n", __FUNCTION__);
 	printk(KERN_INFO "%s loading...\n", DRIVER_NAME);
 
@@ -277,7 +296,7 @@ static int __init radioberry_init(void) {
 	printk(KERN_INFO "Radioberry: registered correctly with major number %d\n", majorNumber);
 
    // Register the device class
-   radioberryCharClass = class_create(THIS_MODULE, CLASS_NAME);
+   radioberryCharClass = class_create(CLASS_NAME);
    if (IS_ERR(radioberryCharClass)){                
       unregister_chrdev(majorNumber, DEVICE_NAME);
       printk(KERN_ALERT "Failed to register device class\n");
@@ -294,27 +313,27 @@ static int __init radioberry_init(void) {
       return PTR_ERR(radioberryCharDevice);
    }
    printk(KERN_INFO "Radioberry char: device class created correctly\n"); 
-	
+
 	mutex_init(&radioberry_mutex);
 	init_waitqueue_head(&rx_sample_queue);
 	
-	//configure irq.
-	gpio_request(gpioRxSamplesiPin, "sysfs");       
-	gpio_direction_input(gpioRxSamplesiPin);        
-	gpio_export(gpioRxSamplesiPin, false); 	
-	
-	printk(KERN_INFO "Radioberry: The rx sample state is currently: %d\n", gpio_get_value(gpioRxSamplesiPin));
+
+	printk(KERN_INFO "Radioberry: The rx sample state is currently: %d\n", gpiod_get_value(gpio_desc));
 
 	// GPIO numbers and IRQ numbers are not the same! This function performs the mapping for us
-	irqNumber = gpio_to_irq(gpioRxSamplesiPin);
+	// Get the IRQ number for the GPIO pin
+
+	
 	printk(KERN_INFO "Radioberry: The rx samples pin is mapped to IRQ: %d\n", irqNumber);
 
 	// This next call requests an interrupt line
+	if (irqNumber > 0) {
 	result = request_irq(irqNumber,             
 						(irq_handler_t) radioberry_irq_handler, 
 						IRQF_TRIGGER_RISING,   // Interrupt on rising edge  RQF_TRIGGER_RISING
 						"radioberry_rx_irq",    // Used in /proc/interrupts to identify the owner
-						NULL);                 
+					NULL);
+	}					
 
 	printk(KERN_INFO "Radioberry: The interrupt request result is: %d\n", result);	
 	
@@ -328,14 +347,13 @@ static int __init radioberry_init(void) {
 }
 
 static void __exit radioberry_exit(void) {
-	int i;
-	dev_t devno;
-	dev_t devno_top;
 	
 	printk(KERN_INFO "inside %s function \n", __FUNCTION__);
 	
-	free_irq(irqNumber, NULL);
-    gpio_unexport(gpioRxSamplesiPin); 
+	if (irqNumber > 0)
+		free_irq(irqNumber, NULL);
+    if (gpio_desc != NULL)
+		gpiod_put(gpio_desc);
 	
 	platform_driver_unregister(&radioberry_driver);
 	

--- a/SBC/rpi-4/device_driver/driver/radioberry.c
+++ b/SBC/rpi-4/device_driver/driver/radioberry.c
@@ -271,8 +271,8 @@ static int radioberry_probe(struct platform_device *pdev)
 		
 	gpio_desc = gpiod_get(&pdev->dev, "rx-sample", GPIOD_ASIS);
 	if(IS_ERR(gpio_desc)) {
-		printk("Failed to get GPIO rx-sample-gpio\n");
-		return -1 * IS_ERR(gpio_desc);
+		printk(KERN_ALERT "Failed to get GPIO rx-sample-gpio\n");
+		return -1 ;//* IS_ERR(gpio_desc);
 	}
     printk("Got GPIO rx-sample-gpio\n");
 	

--- a/SBC/rpi-4/device_driver/driver/radioberry.c
+++ b/SBC/rpi-4/device_driver/driver/radioberry.c
@@ -294,13 +294,11 @@ static int radioberry_probe(struct platform_device *pdev)
 	// GPIO numbers and IRQ numbers are not the same! This function performs the mapping for us
 	// Get the IRQ number for the GPIO pin
 	// This next call requests an interrupt line
-	if (irqNumber > 0) {
 	result = request_irq(irqNumber,             
 						(irq_handler_t) radioberry_irq_handler, 
 						IRQF_TRIGGER_RISING,   // Interrupt on rising edge  RQF_TRIGGER_RISING
 						"radioberry_rx_irq",    // Used in /proc/interrupts to identify the owner
 					NULL);
-	}					
 
 	printk(KERN_INFO "Radioberry: The interrupt request result is: %d\n", result);	
 	mutex_init(&spi_mutex);

--- a/SBC/rpi-4/device_driver/driver/radioberry.c
+++ b/SBC/rpi-4/device_driver/driver/radioberry.c
@@ -62,29 +62,17 @@ static struct mutex spi_mutex;
 #include "radioberry_gateware.h"
 #include "radioberry_firmware.h"
 
-#define VERSION "94"
+#define VERSION "95"
 
 static DEFINE_MUTEX(radioberry_mutex); 
-static wait_queue_head_t rx_sample_queue;
-
 #define DEVICE_NAME "radioberry"   
 #define DRIVER_NAME "radioberry"
 #define CLASS_NAME  "radioberry"        
 
+static int _nrx = 1;
 static int majorNumber;                  	
 static struct class*  radioberryCharClass  = NULL; 
 static struct device* radioberryCharDevice = NULL; 
-
-#define SAMPLE_BYTES 512
-static int _nrx = 1;
-
-static unsigned int irqNumber; 
-static struct gpio_desc *gpio_desc = NULL;
-
-static irq_handler_t radioberry_irq_handler(unsigned int irq, void *dev_id, struct pt_regs *regs){
-	wake_up_interruptible(&rx_sample_queue);
-    return (irq_handler_t) IRQ_HANDLED;      
-}
 
 static void firmware_load(const char *firmware, int size) {
 	printk(KERN_INFO "inside %s function \n", __FUNCTION__);
@@ -120,13 +108,81 @@ static void loading_radioberry_gateware(struct device *dev) {
 	release_firmware(fw_entry);
 }
 
-ssize_t radioberry_read(struct file *flip, char *buf, size_t count, loff_t *pos) {
-	unsigned char rx_stream[SAMPLE_BYTES]={};	
-	wait_event_interruptible(rx_sample_queue, (((*rpi_read_io) >> 25) & 1) != 0);
-	count = rxStream(_nrx, rx_stream);  
-	if (copy_to_user((char *)buf, &rx_stream, count)) return -EFAULT;
-	return count;	
+ssize_t radioberry_read(struct file *flip, char *buf, size_t count, loff_t *pos){	
+	unsigned char iqdata[SAMPLE_BYTES]={};	
+	int nr_samples = (_nrx == 1)? 63 : (_nrx == 2)? 72: (_nrx ==3)? 75: (_nrx ==4)? 76: (_nrx ==5)? 75: (_nrx ==6)? 78: (_nrx ==7)? 77: 80;
+	uint32_t value = 0;
+	
+	int s = 0, i = 0;
+	while ((((*rpi_read_io) >> 25) & 1) == 0)
+		udelay(100);	
+	for (s = 0; s < nr_samples; s++) {	
+		value = 0;
+		*rpi_set_io_high = (1<<RPI_RX_CLK);
+		value = *rpi_read_io;
+		iqdata[i] =  (((value >> 23) & 1) << 7);
+		iqdata[i] |=  (((value >> 20) & 1) << 6);
+		iqdata[i] |=  (((value >> 19) & 1) << 5);
+		iqdata[i] |=  (((value >> 18) & 1) << 4);
+		iqdata[i] |=  (((value >> 16) & 1) << 3);
+		iqdata[i] |=  (((value >> 13) & 1) << 2);
+		iqdata[i] |=  (((value >> 12) & 1) << 1);
+		iqdata[i++] |=  (((value >> 5) & 1));							
+		*rpi_set_io_low = (1<<RPI_RX_CLK);
+		value = *rpi_read_io;
+		iqdata[i] =  (((value >> 23) & 1) << 7);
+		iqdata[i] |=  (((value >> 20) & 1) << 6);
+		iqdata[i] |=  (((value >> 19) & 1) << 5);
+		iqdata[i] |=  (((value >> 18) & 1) << 4);
+		iqdata[i] |=  (((value >> 16) & 1) << 3);
+		iqdata[i] |=  (((value >> 13) & 1) << 2);
+		iqdata[i] |=  (((value >> 12) & 1) << 1);
+		iqdata[i++] |=  (((value >> 5) & 1));							
+		*rpi_set_io_high = (1<<RPI_RX_CLK);
+		value = *rpi_read_io;
+		iqdata[i] =  (((value >> 23) & 1) << 7);
+		iqdata[i] |=  (((value >> 20) & 1) << 6);
+		iqdata[i] |=  (((value >> 19) & 1) << 5);
+		iqdata[i] |=  (((value >> 18) & 1) << 4);
+		iqdata[i] |=  (((value >> 16) & 1) << 3);
+		iqdata[i] |=  (((value >> 13) & 1) << 2);
+		iqdata[i] |=  (((value >> 12) & 1) << 1);
+		iqdata[i++] |=  (((value >> 5) & 1));							
+		*rpi_set_io_low = (1<<RPI_RX_CLK);
+		value = *rpi_read_io;
+		iqdata[i] =  (((value >> 23) & 1) << 7);
+		iqdata[i] |=  (((value >> 20) & 1) << 6);
+		iqdata[i] |=  (((value >> 19) & 1) << 5);
+		iqdata[i] |=  (((value >> 18) & 1) << 4);
+		iqdata[i] |=  (((value >> 16) & 1) << 3);
+		iqdata[i] |=  (((value >> 13) & 1) << 2);
+		iqdata[i] |=  (((value >> 12) & 1) << 1);
+		iqdata[i++] |=  (((value >> 5) & 1));							
+		*rpi_set_io_high = (1<<RPI_RX_CLK);
+		value = *rpi_read_io;
+		iqdata[i] =  (((value >> 23) & 1) << 7);
+		iqdata[i] |=  (((value >> 20) & 1) << 6);
+		iqdata[i] |=  (((value >> 19) & 1) << 5);
+		iqdata[i] |=  (((value >> 18) & 1) << 4);
+		iqdata[i] |=  (((value >> 16) & 1) << 3);
+		iqdata[i] |=  (((value >> 13) & 1) << 2);
+		iqdata[i] |=  (((value >> 12) & 1) << 1);
+		iqdata[i++] |=  (((value >> 5) & 1));							
+		*rpi_set_io_low = (1<<RPI_RX_CLK);
+		value = *rpi_read_io;
+		iqdata[i] =  (((value >> 23) & 1) << 7);
+		iqdata[i] |=  (((value >> 20) & 1) << 6);
+		iqdata[i] |=  (((value >> 19) & 1) << 5);
+		iqdata[i] |=  (((value >> 18) & 1) << 4);
+		iqdata[i] |=  (((value >> 16) & 1) << 3);
+		iqdata[i] |=  (((value >> 13) & 1) << 2);
+		iqdata[i] |=  (((value >> 12) & 1) << 1);
+		iqdata[i++] |=  (((value >> 5) & 1));
+	}
+	if (copy_to_user((char *)buf, &iqdata, nr_samples * 6)) return -EFAULT;
+	return nr_samples * 6;	
 }
+
 
 static ssize_t radioberry_write(struct file *flip, const char *buf, size_t count, loff_t *pos) {
  
@@ -195,7 +251,7 @@ static long radioberry_ioctl(struct file *fp, unsigned int cmd, unsigned long ar
 			if ((data[1] & 0xFE)  == 0x00) lnrx = ((data[5] & 0x38) >> 3) + 1;
 	
 			mutex_lock(&spi_mutex);
-			spiXfer(0, data, data, 6); //spi channel 0 // tell the gateware the command.
+			spiXfer(0,data, data, 6); //spi channel 0 // tell the gateware the command.
 			mutex_unlock(&spi_mutex);
 			
 			_nrx = lnrx;
@@ -268,39 +324,6 @@ static int radioberry_probe(struct platform_device *pdev)
 	  return PTR_ERR(radioberryCharDevice);
 	}
 	printk(KERN_INFO "Radioberry char: device class created correctly\n"); 
-		
-	gpio_desc = gpiod_get(&pdev->dev, "rx-sample", GPIOD_ASIS);
-	if(IS_ERR(gpio_desc)) {
-		printk(KERN_ALERT "Failed to get GPIO rx-sample-gpio\n");
-		return -1 ;//* IS_ERR(gpio_desc);
-	}
-    printk("Got GPIO rx-sample-gpio\n");
-	
-	int retval = gpiod_direction_input(gpio_desc);
-	if (retval) {
-        printk("Failed to set GPIO pin direction\n");
-        return retval;
-    }
-	irqNumber = gpiod_to_irq(gpio_desc);
-    if (irqNumber < 0) {
-        printk("Failed to get IRQ number for GPIO pin\n");
-        return irqNumber;
-    }
-	printk(KERN_INFO "Radioberry: The rx samples pin is mapped to IRQ: %d\n", irqNumber);
-	mutex_init(&radioberry_mutex);
-	init_waitqueue_head(&rx_sample_queue);
-	printk(KERN_INFO "Radioberry: The rx sample state is currently: %d\n", gpiod_get_value(gpio_desc));
-
-	// GPIO numbers and IRQ numbers are not the same! This function performs the mapping for us
-	// Get the IRQ number for the GPIO pin
-	// This next call requests an interrupt line
-	result = request_irq(irqNumber,             
-						(irq_handler_t) radioberry_irq_handler, 
-						IRQF_TRIGGER_RISING,   // Interrupt on rising edge  RQF_TRIGGER_RISING
-						"radioberry_rx_irq",    // Used in /proc/interrupts to identify the owner
-					NULL);
-
-	printk(KERN_INFO "Radioberry: The interrupt request result is: %d\n", result);	
 	mutex_init(&spi_mutex);
 	initialize_rpi();
 	loading_radioberry_gateware(radioberryCharDevice);
@@ -343,14 +366,7 @@ static int __init radioberry_init(void) {
 static void __exit radioberry_exit(void) {
 	
 	printk(KERN_INFO "inside %s function \n", __FUNCTION__);
-	
-	if (irqNumber > 0)
-		free_irq(irqNumber, NULL);
-    if (gpio_desc != NULL)
-		gpiod_put(gpio_desc);
-	
-	platform_driver_unregister(&radioberry_driver);
-	
+	platform_driver_unregister(&radioberry_driver);	
 	device_destroy(radioberryCharClass, MKDEV(majorNumber, 0));     
 	class_unregister(radioberryCharClass);                        
 	class_destroy(radioberryCharClass);                             

--- a/SBC/rpi-4/device_driver/driver/radioberry.dts
+++ b/SBC/rpi-4/device_driver/driver/radioberry.dts
@@ -19,32 +19,17 @@
  *
  */
 
-
 /dts-v1/;
 /plugin/;
-
 /{
     compatible = "brcm,bcm2711";
-	
-	fragment@0 {
-		target = <&gpio>;  
-		__overlay__ {
-			radioberry_gpio: radioberry_gpio {
-				brcm,pins = <22 26 27 13 24>;		
-				brcm,function = <0x00 0x00 0x01 0x01 0x01>;  	//0 =input; 1=output
-				};
-			};
-	};
-
-	fragment@1 {
-		target-path = "/";
-		__overlay__ {
-				radio: radio {
-					pinctrl-names = "default";
-					pinctrl-0 = <&radioberry_gpio>;
-					compatible = "sdr,radioberry";
-					gateware-gpios = <&gpio 22 0>, <&gpio 26 0>, <&gpio 27 0>, <&gpio 13 0>, <&gpio 24 0>;
-				};
-			};
-	};
+        fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                                radio {
+                                        compatible = "sdr,radioberry";
+                                        rx-sample-gpio = <&gpio 25 0>;
+                                };
+                        };
+        };
 };

--- a/SBC/rpi-4/device_driver/driver/radioberry_firmware.h
+++ b/SBC/rpi-4/device_driver/driver/radioberry_firmware.h
@@ -35,9 +35,8 @@
 #define SPI_LTOH 4
 #define SPI_DC   5
 
+#define SAMPLE_BYTES 512
 static int initialize_firmware(void);
-int rxStream(int nrx, unsigned char stream[]);
-void read_iq_sample(int lnrx, int iqs, unsigned char iqdata[]);
 int spiXfer(int spi_channel, char *txBuf, char *rxBuf, unsigned cnt);
 int write_iq_sample(unsigned char tx_iqdata[]);
 
@@ -124,45 +123,6 @@ int spiXfer(int spi_channel, char *txBuf, char *rxBuf, unsigned cnt){
    spiReg[SPI_CS] = spiDefaults; /* stop */
    
    return 0;
-}
-
-int rxStream(int nrx, unsigned char stream[]){
-	unsigned char iqdata[6];
-	int iqs = 1;
-	
-	int nr_samples = (nrx == 1)? 63 : (nrx == 2)? 72: (nrx ==3)? 75: (nrx ==4)? 76: (nrx ==5)? 75: (nrx ==6)? 78: (nrx ==7)? 77: 80;
-	
-	int s = 0;
-	for (s = 0; s < nr_samples; s++) {	
-		read_iq_sample(nrx, iqs, iqdata);
-		memcpy(stream + (s * 6), iqdata, 6);
-		iqs++;
-	}
-	return nr_samples * 6;
-}
-
-void read_iq_sample(int lnrx, int iqs, unsigned char iqdata[]){
-	uint32_t value = 0;
-		
-	int i = 0;	
-	for (i = 0; i < 6 ; i++) {
-		
-		if (i % 2 == 0) {
-			*rpi_set_io_high = (1<<RPI_RX_CLK);
-			value = *rpi_read_io;
-		} else {		
-			*rpi_set_io_low = (1<<RPI_RX_CLK);
-			value = *rpi_read_io;
-		}
-		iqdata[i] =  (((value >> 23) & 1) << 7);
-		iqdata[i] |=  (((value >> 20) & 1) << 6);
-		iqdata[i] |=  (((value >> 19) & 1) << 5);
-		iqdata[i] |=  (((value >> 18) & 1) << 4);
-		iqdata[i] |=  (((value >> 16) & 1) << 3);
-		iqdata[i] |=  (((value >> 13) & 1) << 2);
-		iqdata[i] |=  (((value >> 12) & 1) << 1);
-		iqdata[i] |=  (((value >> 5) & 1));						
-	}		
 }
 
 int write_iq_sample(unsigned char tx_iqdata[]) {


### PR DESCRIPTION
Radioberry driver update for kernel rpi6.6.y the fix updates the GPIO to the newer descriptive interface and uses the overlay to connect to pin 25 IRQ.
The file radioberry_install.sh is updated by qrp73 to support installation for new and older kernels.
This fix also contains a fix for SoapyRadioberry transmit function. The data conversion was not correct. 