### PR TITLE
SoapyRadioberrySDR: use std::runtime_error

### DIFF
--- a/SBC/rpi-4/SoapyRadioberrySDR/SoapyRadioberrySettings.cpp
+++ b/SBC/rpi-4/SoapyRadioberrySDR/SoapyRadioberrySettings.cpp
@@ -21,9 +21,9 @@ SoapyRadioberry::SoapyRadioberry( const SoapySDR::Kwargs &args ){
 		i2c_ptr = std::make_unique<rpihw::driver::i2c>(rpihw::driver::i2c("/dev/i2c-1"));
 		i2c_available = true;
 	}
-	catch (std::string s)
+	catch (std::runtime_error e)
 	{
-		printf("I2c not found %s", s.c_str());
+		printf("I2c not found %s", e.what());
 		i2c_available = false;
 	}
 }
@@ -295,9 +295,9 @@ void SoapyRadioberry::writeI2C(const int addr, const std::string &data)
 	{
 		i2c_ptr->write((uint8_t *)data.c_str(), data.size());
 	}
-	catch (std::string s)
+	catch (std::runtime_error e)
 	{
-		printf("%s", s.c_str());
+		printf("%s", e.what());
 	}
 }
 
@@ -316,9 +316,9 @@ std::string SoapyRadioberry::readI2C(const int addr, const size_t numBytes)
 		i2c_ptr->read((uint8_t *)data.c_str(), numBytes);
 		data.resize(numBytes);
 	}
-	catch (std::string s)
+	catch (std::runtime_error e)
 	{
-		printf("%s", s.c_str());
+		printf("%s", e.what());
 	}
 	return data;
 }

--- a/SBC/rpi-4/SoapyRadioberrySDR/i2c.cpp
+++ b/SBC/rpi-4/SoapyRadioberrySDR/i2c.cpp
@@ -32,7 +32,7 @@ i2c::i2c( const std::string &dev_path)
 	m_dev_fd = open( m_dev_path.c_str(), O_RDWR );
 
 	if ( m_dev_fd < 0 )
-		throw "(Fatal) `i2c`: can't open I2C device \n"  ;
+		throw std::runtime_error( "(Fatal) `i2c`: can't open I2C device \n" );
 
 }
 
@@ -41,7 +41,7 @@ void i2c::addr(uint8_t addr)
 		m_addr = addr;
 		// Select slave device
 		if(ioctl(m_dev_fd, I2C_SLAVE, addr) < 0)
-			throw "(Fatal) `i2c`: can't select slave device \n";
+			throw std::runtime_error( "(Fatal) `i2c`: can't select slave device \n" );
 	}
 	
 i2c::~i2c() {
@@ -54,7 +54,7 @@ void
 i2c::write( uint8_t *data, uint8_t size ) {
 
 	if ( ::write( m_dev_fd, data, size ) != size )
-		throw "(Fatal) `i2c`: failed to write to the bus\n";
+		throw std::runtime_error( "(Fatal) `i2c`: failed to write to the bus\n" );
 }
 
 void


### PR DESCRIPTION
Change throw in `SoapyRadioberrySDR/i2c.cpp`
and catch in `SoapyRadioberrySDR/SoapyRadioberrySettings.cpp`
to `use std::runtime_error`.
This fixes a Segmentation Fault that is triggered when `/dev/i2c-1` is not found.